### PR TITLE
Fix circular dependency

### DIFF
--- a/src/collective/jekyll/profiles/default/import_steps.xml
+++ b/src/collective/jekyll/profiles/default/import_steps.xml
@@ -4,7 +4,7 @@
                version="20120714-01"
                handler="collective.jekyll.setuphandlers.setupSettings"
                title="Collective Jekyll: setup settings">
-    <dependency step="registry" />
+    <dependency step="plone.app.registry" />
     Setup settings for Collective Jekyll.
   </import-step>
 </import-steps>


### PR DESCRIPTION
By having import step handler setupSettings be dependent on `registry` causes a circular dependency warning. The proper dependency should be `plone.app.registry` (as often seen in various other products making changes in registry within setuphandlers).